### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,10 +3,19 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     rules: {
       '@typescript-eslint/prefer-readonly-parameter-types': 'off',
+    },
+  },
+  {
+    files: ['packages/output-view/test/**/*.ts'],
+    rules: {
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
 ]

--- a/packages/output-view/src/parts/GetBadgeVirtualDom/GetBadgeVirtualDom.ts
+++ b/packages/output-view/src/parts/GetBadgeVirtualDom/GetBadgeVirtualDom.ts
@@ -1,11 +1,11 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
-import { text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import { mergeClassNames, text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 
 export const getBadgeVirtualDom = (className: string, count: number): readonly VirtualDomNode[] => {
   return [
     {
       childCount: 1,
-      className: `Badge ${className}`,
+      className: mergeClassNames('Badge', className),
       type: VirtualDomElements.Div,
     },
     text(String(count)),

--- a/packages/output-view/src/parts/GetContentDom/GetContentDom.ts
+++ b/packages/output-view/src/parts/GetContentDom/GetContentDom.ts
@@ -1,8 +1,9 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
-import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import { AriaRoles, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { Line } from '../Line/Line.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { getLineDom } from '../GetLineDom/GetLineDom.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 export const getContentDom = (lines: readonly Line[], error: string): readonly VirtualDomNode[] => {
   if (error) {
@@ -12,8 +13,8 @@ export const getContentDom = (lines: readonly Line[], error: string): readonly V
     {
       childCount: lines.length,
       className: ClassNames.OutputContent,
-      role: 'log',
-      tabIndex: 0,
+      role: AriaRoles.Log,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     ...lines.flatMap(getLineDom),

--- a/packages/output-view/src/parts/GetErrorDom/GetErrorDom.ts
+++ b/packages/output-view/src/parts/GetErrorDom/GetErrorDom.ts
@@ -3,6 +3,7 @@ import { text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as ErrorCode from '../ErrorCode/ErrorCode.ts'
 import { getLogFileNotFoundDom } from '../GetLogFileNotFoundDom/GetLogFileNotFoundDom.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 export const getErrorDom = (errorCode: number, error: string): readonly VirtualDomNode[] => {
   if (!error) {
@@ -15,7 +16,7 @@ export const getErrorDom = (errorCode: number, error: string): readonly VirtualD
     {
       childCount: 1,
       className: ClassNames.Error,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     text(error),

--- a/packages/output-view/src/parts/GetLogFileNotFoundDom/GetLogFileNotFoundDom.ts
+++ b/packages/output-view/src/parts/GetLogFileNotFoundDom/GetLogFileNotFoundDom.ts
@@ -2,13 +2,14 @@ import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as OutputStrings from '../OutputStrings/OutputStrings.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 export const getLogFileNotFoundDom = (): readonly VirtualDomNode[] => {
   return [
     {
       childCount: 1,
       className: ClassNames.Message,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     text(OutputStrings.logFileNotFound()),

--- a/packages/output-view/src/parts/TabIndex/TabIndex.ts
+++ b/packages/output-view/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0

--- a/packages/output-view/test/GetBadgeVirtualDom.test.ts
+++ b/packages/output-view/test/GetBadgeVirtualDom.test.ts
@@ -56,7 +56,7 @@ test('getBadgeVirtualDom with empty className', () => {
   expect(result).toHaveLength(2)
   expect(result[0]).toEqual({
     childCount: 1,
-    className: 'Badge ',
+    className: 'Badge',
     type: VirtualDomElements.Div,
   })
   expect(result[1]).toEqual({


### PR DESCRIPTION
Enable the shared recommended virtual-DOM ESLint preset.

- use shared ARIA-role and class-name constants/helpers
- add a named focusable tab-index constant
- normalize empty optional badge classes without trailing whitespace
- keep literal VDOM fixtures and state assertions under test-only exceptions

Validation:
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` (171 passed, 2 skipped)
- `npm run measure` (usedSize: 428060)