### PR TITLE
fix: make output filtering case insensitive

### DIFF
--- a/packages/output-view/src/parts/FilterItems/FilterItems.ts
+++ b/packages/output-view/src/parts/FilterItems/FilterItems.ts
@@ -13,5 +13,6 @@ export const filterItems = (items: readonly Line[], filterValue: string): readon
   if (!filterValue) {
     return items
   }
-  return items.filter((parts) => getTextFromParts(parts).includes(filterValue))
+  const normalizedFilterValue = filterValue.toLowerCase()
+  return items.filter((parts) => getTextFromParts(parts).toLowerCase().includes(normalizedFilterValue))
 }

--- a/packages/output-view/test/FilterItems.test.ts
+++ b/packages/output-view/test/FilterItems.test.ts
@@ -16,3 +16,9 @@ test('filterItems - filters by substring', () => {
   ]
   expect(filterItems(items, 'a')).toEqual(items)
 })
+
+test('filterItems - filters case insensitively', () => {
+  const matchingItem: Line = [{ type: LinePartType.Text, value: 'StatusBar.handleItemsChanged' }]
+  const items: readonly Line[] = [matchingItem, [{ type: LinePartType.Text, value: 'handleBlur instance not found' }]]
+  expect(filterItems(items, 'status')).toEqual([matchingItem])
+})


### PR DESCRIPTION
Make output filtering case insensitive so lowercase queries match mixed-case output lines. Adds regression coverage for status matching StatusBar.