### PR TITLE
feature: test large output channel data

### DIFF
--- a/packages/e2e/fixtures/sample.output-channel-large-data/extension.json
+++ b/packages/e2e/fixtures/sample.output-channel-large-data/extension.json
@@ -1,0 +1,5 @@
+{
+  "browser": "main.js",
+  "main": "main.js",
+  "activation": ["onOutput"]
+}

--- a/packages/e2e/fixtures/sample.output-channel-large-data/main.js
+++ b/packages/e2e/fixtures/sample.output-channel-large-data/main.js
@@ -1,0 +1,18 @@
+const lineCount = 10_000
+const filterTarget = 'unique-filter-target'
+
+const outputChannelProvider = {
+  id: 'large-data',
+  label: 'Large Data',
+}
+
+const getLine = (index) => {
+  const suffix = index === lineCount - 1 ? ` ${filterTarget}` : ''
+  return `line ${index.toString().padStart(5, '0')}${suffix}`
+}
+
+export const activate = async () => {
+  const channel = vscode.registerOutputChannel(outputChannelProvider)
+  const output = Array.from({ length: lineCount }, (_, index) => getLine(index)).join('\n')
+  await channel.append(output)
+}

--- a/packages/e2e/src/output.large-data.ts
+++ b/packages/e2e/src/output.large-data.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'output.large-data'
+
+const lineCount = 10_000
+const filterTarget = 'unique-filter-target'
+
+export const test: Test = async ({ expect, Extension, FileSystem, Locator, Output }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.writeFile(`${tmpDir}/test.txt`, 'div')
+  const extensionUri = import.meta.resolve('../fixtures/sample.output-channel-large-data')
+  await Extension.addWebExtension(extensionUri)
+  await Output.show()
+
+  // act
+  await Output.selectChannel('large-data')
+
+  // assert
+  const output = Locator('.Output')
+  await expect(output).toBeVisible()
+  const lines = Locator('.OutputContent .Line')
+  await expect(lines).toHaveCount(lineCount + 1)
+  const lastDataLine = lines.nth(lineCount - 1)
+  await expect(lastDataLine).toHaveText(`line 09999 ${filterTarget}`)
+
+  // act
+  await Output.handleFilterInput(filterTarget)
+
+  // assert
+  await expect(lines).toHaveCount(1)
+  await expect(lines.first()).toHaveText(`line 09999 ${filterTarget}`)
+  await expect(output).toBeVisible()
+}


### PR DESCRIPTION
Adds an end-to-end Output Channel scenario with 10,000 log lines. Verifies the complete output renders and filtering reduces it to the unique matching line without losing the Output view.