### PR TITLE
feature: detect stack trace source links

### DIFF
--- a/packages/e2e/fixtures/sample.output-channel-structured/main.js
+++ b/packages/e2e/fixtures/sample.output-channel-structured/main.js
@@ -26,6 +26,7 @@ export const activate = () => {
       createRecord('warning', 'deprecated API', 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js', 3455),
       createRecord('error', 'request failed', 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js', 77),
       createRecord('info', 'ready'),
+      '    at load$1 (lvce://-/packages/renderer-process/dist/rendererProcessMain.js:8726:11)',
     ].join('\n'),
   )
 }

--- a/packages/e2e/src/output.structured-source.ts
+++ b/packages/e2e/src/output.structured-source.ts
@@ -11,9 +11,12 @@ export const test: Test = async ({ expect, Extension, FileSystem, Locator, Outpu
   await Output.selectChannel('structured')
 
   const links = Locator('.OutputContent .OutputSourceLink')
-  await expect(links).toHaveCount(2)
+  await expect(links).toHaveCount(3)
   const warningSource = links.first()
   await expect(warningSource).toHaveText('rendererWorkerMain.js:3455')
   await expect(warningSource).toHaveAttribute('href', 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js')
   await expect(warningSource).toHaveAttribute('target', '_blank')
+  const stackSource = links.nth(2)
+  await expect(stackSource).toHaveText('lvce://-/packages/renderer-process/dist/rendererProcessMain.js:8726:11')
+  await expect(stackSource).toHaveAttribute('href', 'lvce://-/packages/renderer-process/dist/rendererProcessMain.js')
 }

--- a/packages/output-view/src/parts/GetLinkMatch/GetLinkMatch.ts
+++ b/packages/output-view/src/parts/GetLinkMatch/GetLinkMatch.ts
@@ -1,6 +1,15 @@
-const RE_URL = /(?:https?:\/\/\S+|file:\/\/\S+)/
+const RE_URL = /(?:https?:\/\/|file:\/\/|lvce(?:-oss)?:\/\/)\S+/
+const trailingPunctuation = '!),.;?]}'
+
+const trimTrailingPunctuation = (value: string): string => {
+  let end = value.length
+  while (end > 0 && trailingPunctuation.includes(value[end - 1])) {
+    end--
+  }
+  return value.slice(0, end)
+}
 
 export const getLinkMatch = (text: string): string | null => {
   const match = text.match(RE_URL)
-  return match ? match[0] : null
+  return match ? trimTrailingPunctuation(match[0]) : null
 }

--- a/packages/output-view/src/parts/ParseLine/ParseLine.ts
+++ b/packages/output-view/src/parts/ParseLine/ParseLine.ts
@@ -1,7 +1,23 @@
 import type { LinePart } from '../LinePart/LinePart.ts'
+import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { getLinkMatch } from '../GetLinkMatch/GetLinkMatch.ts'
 import * as LinePartType from '../LinePartType/LinePartType.ts'
 import { parseStructuredLogLine } from '../ParseStructuredLogLine/ParseStructuredLogLine.ts'
+
+const RE_SOURCE_LINK = /^lvce(?:-oss)?:\/\//
+const RE_SOURCE_LOCATION = /:\d+(?::\d+)?$/
+
+const getLinkPart = (match: string): LinePart => {
+  if (RE_SOURCE_LINK.test(match)) {
+    return {
+      className: ClassNames.OutputSourceLink,
+      label: match,
+      type: LinePartType.Link,
+      value: match.replace(RE_SOURCE_LOCATION, ''),
+    }
+  }
+  return { type: LinePartType.Link, value: match }
+}
 
 export const parseLine = (line: string): readonly LinePart[] => {
   const structuredLine = parseStructuredLogLine(line)
@@ -22,7 +38,7 @@ export const parseLine = (line: string): readonly LinePart[] => {
     if (index > 0) {
       parts.push({ type: LinePartType.Text, value: rest.slice(0, index) })
     }
-    parts.push({ type: LinePartType.Link, value: match })
+    parts.push(getLinkPart(match))
     rest = rest.slice(index + match.length)
   }
   if (parts.length === 0) {

--- a/packages/output-view/test/GetLinkMatch.test.ts
+++ b/packages/output-view/test/GetLinkMatch.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable jest/no-disabled-tests, unicorn/prefer-https */
+/* eslint-disable unicorn/prefer-https */
 import { test, expect } from '@jest/globals'
 import { getLinkMatch } from '../src/parts/GetLinkMatch/GetLinkMatch.ts'
 
@@ -10,10 +10,22 @@ test('getLinkMatch - http link', () => {
   expect(getLinkMatch('see http://example.com now')).toBe('http://example.com')
 })
 
-test.skip('getLinkMatch - https link', () => {
-  expect(getLinkMatch('go to https://example.com!')).toBe('https://example.com!'.slice(0, 'https://example.com'.length))
+test('getLinkMatch - https link excludes trailing punctuation', () => {
+  expect(getLinkMatch('go to https://example.com!')).toBe('https://example.com')
 })
 
 test('getLinkMatch - file link', () => {
   expect(getLinkMatch('open file:///tmp/log.txt please')).toBe('file:///tmp/log.txt')
+})
+
+test('getLinkMatch - lvce stack trace link', () => {
+  expect(getLinkMatch('at load$1 (lvce://-/537bcf0/packages/renderer-process/dist/rendererProcessMain.js:8726:11)')).toBe(
+    'lvce://-/537bcf0/packages/renderer-process/dist/rendererProcessMain.js:8726:11',
+  )
+})
+
+test('getLinkMatch - lvce oss stack trace link', () => {
+  expect(getLinkMatch('at load$1 (lvce-oss://-/packages/renderer-process/dist/rendererProcessMain.js:8726:11)')).toBe(
+    'lvce-oss://-/packages/renderer-process/dist/rendererProcessMain.js:8726:11',
+  )
 })

--- a/packages/output-view/test/ParseLine.test.ts
+++ b/packages/output-view/test/ParseLine.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@jest/globals'
+import * as LinePartType from '../src/parts/LinePartType/LinePartType.ts'
+import { parseLine } from '../src/parts/ParseLine/ParseLine.ts'
+
+test('parseLine - renders an lvce stack frame as a source link', () => {
+  expect(parseLine('    at load$1 (lvce://-/537bcf0/packages/renderer-process/dist/rendererProcessMain.js:8726:11)')).toEqual([
+    { type: LinePartType.Text, value: '    at load$1 (' },
+    {
+      className: 'OutputSourceLink',
+      label: 'lvce://-/537bcf0/packages/renderer-process/dist/rendererProcessMain.js:8726:11',
+      type: LinePartType.Link,
+      value: 'lvce://-/537bcf0/packages/renderer-process/dist/rendererProcessMain.js',
+    },
+    { type: LinePartType.Text, value: ')' },
+  ])
+})
+
+test('parseLine - keeps ordinary web links as external links', () => {
+  expect(parseLine('see https://example.com.')).toEqual([
+    { type: LinePartType.Text, value: 'see ' },
+    { type: LinePartType.Link, value: 'https://example.com' },
+    { type: LinePartType.Text, value: '.' },
+  ])
+})


### PR DESCRIPTION
Detect LVCE source URLs in plain output, including stack trace frames, and render them through the editor-opening source link path. Also excludes trailing punctuation and adds unit and e2e regression coverage.