### PR TITLE
fix: open output source links at location

### DIFF
--- a/packages/e2e/src/output.structured-source.ts
+++ b/packages/e2e/src/output.structured-source.ts
@@ -4,7 +4,8 @@ export const name = 'output.structured-source'
 
 export const test: Test = async ({ Command, Editor, expect, Extension, FileSystem, Locator, Output }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
-  await FileSystem.writeFile(`${tmpDir}/test.txt`, 'div')
+  const testUri = `${tmpDir}/test.txt`
+  await FileSystem.writeFile(testUri, 'first\nsecond\nthird')
   const extensionUri = import.meta.resolve('../fixtures/sample.output-channel-structured')
   await Extension.addWebExtension(extensionUri)
   await Output.show()
@@ -15,13 +16,13 @@ export const test: Test = async ({ Command, Editor, expect, Extension, FileSyste
   const warningSource = links.first()
   await expect(warningSource).toHaveText('rendererWorkerMain.js:3455')
   await expect(warningSource).toHaveAttribute('href', 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js')
-  await expect(warningSource).toHaveAttribute('data-line-number', '3455')
+  await expect(warningSource).toHaveAttribute('data-line', '3455')
   await expect(warningSource).toHaveAttribute('target', '_blank')
   const stackSource = links.nth(2)
   await expect(stackSource).toHaveText('lvce://-/packages/renderer-process/dist/rendererProcessMain.js:8726:11')
   await expect(stackSource).toHaveAttribute('href', 'lvce://-/packages/renderer-process/dist/rendererProcessMain.js')
-  await expect(stackSource).toHaveAttribute('data-line-number', '8726')
-  await expect(stackSource).toHaveAttribute('data-column-number', '11')
-  await Command.execute('Output.handleSourceLinkClick', 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js', '3455')
-  await Editor.shouldHaveSelections(new Uint32Array([3454, 0, 3454, 0]))
+  await expect(stackSource).toHaveAttribute('data-line', '8726')
+  await expect(stackSource).toHaveAttribute('data-column', '11')
+  await Command.execute('Output.handleSourceLinkClick', testUri, '3')
+  await Editor.shouldHaveSelections(new Uint32Array([2, 0, 2, 0]))
 }

--- a/packages/e2e/src/output.structured-source.ts
+++ b/packages/e2e/src/output.structured-source.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'output.structured-source'
 
-export const test: Test = async ({ expect, Extension, FileSystem, Locator, Output }) => {
+export const test: Test = async ({ Command, Editor, expect, Extension, FileSystem, Locator, Output }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   await FileSystem.writeFile(`${tmpDir}/test.txt`, 'div')
   const extensionUri = import.meta.resolve('../fixtures/sample.output-channel-structured')
@@ -15,8 +15,13 @@ export const test: Test = async ({ expect, Extension, FileSystem, Locator, Outpu
   const warningSource = links.first()
   await expect(warningSource).toHaveText('rendererWorkerMain.js:3455')
   await expect(warningSource).toHaveAttribute('href', 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js')
+  await expect(warningSource).toHaveAttribute('data-line-number', '3455')
   await expect(warningSource).toHaveAttribute('target', '_blank')
   const stackSource = links.nth(2)
   await expect(stackSource).toHaveText('lvce://-/packages/renderer-process/dist/rendererProcessMain.js:8726:11')
   await expect(stackSource).toHaveAttribute('href', 'lvce://-/packages/renderer-process/dist/rendererProcessMain.js')
+  await expect(stackSource).toHaveAttribute('data-line-number', '8726')
+  await expect(stackSource).toHaveAttribute('data-column-number', '11')
+  await Command.execute('Output.handleSourceLinkClick', 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js', '3455')
+  await Editor.shouldHaveSelections(new Uint32Array([3454, 0, 3454, 0]))
 }

--- a/packages/output-view/src/parts/GetLineDom/GetLineDom.ts
+++ b/packages/output-view/src/parts/GetLineDom/GetLineDom.ts
@@ -29,8 +29,8 @@ const getLinePartDom = (part: LinePart): LinePartDom => {
         target: '_blank',
         type: VirtualDomElements.A,
         ...(part.className && { className: part.className }),
-        ...(part.columnNumber !== undefined && { 'data-column-number': part.columnNumber }),
-        ...(part.lineNumber !== undefined && { 'data-line-number': part.lineNumber }),
+        ...(part.columnNumber !== undefined && { 'data-column': part.columnNumber }),
+        ...(part.lineNumber !== undefined && { 'data-line': part.lineNumber }),
         ...(isSourceLink && { onClick: DomEventListenerFunctions.HandleSourceLinkClick }),
       }
       return {

--- a/packages/output-view/src/parts/GetLineDom/GetLineDom.ts
+++ b/packages/output-view/src/parts/GetLineDom/GetLineDom.ts
@@ -29,6 +29,8 @@ const getLinePartDom = (part: LinePart): LinePartDom => {
         target: '_blank',
         type: VirtualDomElements.A,
         ...(part.className && { className: part.className }),
+        ...(part.columnNumber !== undefined && { 'data-column-number': part.columnNumber }),
+        ...(part.lineNumber !== undefined && { 'data-line-number': part.lineNumber }),
         ...(isSourceLink && { onClick: DomEventListenerFunctions.HandleSourceLinkClick }),
       }
       return {

--- a/packages/output-view/src/parts/HandleSourceLinkClick/HandleSourceLinkClick.ts
+++ b/packages/output-view/src/parts/HandleSourceLinkClick/HandleSourceLinkClick.ts
@@ -1,10 +1,25 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { OutputState } from '../OutputState/OutputState.ts'
 
-export const handleSourceLinkClick = async (state: OutputState, uri: string): Promise<OutputState> => {
+export const handleSourceLinkClick = async (
+  state: OutputState,
+  uri: string,
+  lineNumber?: string | number,
+  columnNumber?: string | number,
+): Promise<OutputState> => {
   if (!uri) {
     return state
   }
-  await RendererWorker.invoke('Main.openUri', uri)
+  const line = Number(lineNumber)
+  if (!Number.isSafeInteger(line) || line <= 0) {
+    await RendererWorker.invoke('Main.openUri', uri)
+    return state
+  }
+  const column = Number(columnNumber)
+  const rowIndex = line - 1
+  const columnIndex = Number.isSafeInteger(column) && column > 0 ? column - 1 : 0
+  await RendererWorker.invoke('Main.openUri', uri, true, {
+    selections: new Uint32Array([rowIndex, columnIndex, rowIndex, columnIndex]),
+  })
   return state
 }

--- a/packages/output-view/src/parts/LinkPart/LinkPart.ts
+++ b/packages/output-view/src/parts/LinkPart/LinkPart.ts
@@ -2,7 +2,9 @@ import type * as LinePartType from '../LinePartType/LinePartType.ts'
 
 export interface LinkPart {
   readonly className?: string
+  readonly columnNumber?: number
   readonly label?: string
+  readonly lineNumber?: number
   readonly type: typeof LinePartType.Link
   readonly value: string
 }

--- a/packages/output-view/src/parts/ParseLine/ParseLine.ts
+++ b/packages/output-view/src/parts/ParseLine/ParseLine.ts
@@ -5,15 +5,20 @@ import * as LinePartType from '../LinePartType/LinePartType.ts'
 import { parseStructuredLogLine } from '../ParseStructuredLogLine/ParseStructuredLogLine.ts'
 
 const RE_SOURCE_LINK = /^lvce(?:-oss)?:\/\//
-const RE_SOURCE_LOCATION = /:\d+(?::\d+)?$/
+const RE_SOURCE_LOCATION = /:(\d+)(?::(\d+))?$/
 
 const getLinkPart = (match: string): LinePart => {
   if (RE_SOURCE_LINK.test(match)) {
+    const locationMatch = match.match(RE_SOURCE_LOCATION)
+    const lineNumber = locationMatch ? Number(locationMatch[1]) : undefined
+    const columnNumber = locationMatch?.[2] ? Number(locationMatch[2]) : undefined
     return {
       className: ClassNames.OutputSourceLink,
+      ...(columnNumber !== undefined && { columnNumber }),
       label: match,
+      ...(lineNumber !== undefined && { lineNumber }),
       type: LinePartType.Link,
-      value: match.replace(RE_SOURCE_LOCATION, ''),
+      value: locationMatch ? match.slice(0, -locationMatch[0].length) : match,
     }
   }
   return { type: LinePartType.Link, value: match }

--- a/packages/output-view/src/parts/ParseStructuredLogLine/ParseStructuredLogLine.ts
+++ b/packages/output-view/src/parts/ParseStructuredLogLine/ParseStructuredLogLine.ts
@@ -56,6 +56,12 @@ export const parseStructuredLogLine = (line: string): Line | undefined => {
   return [
     ...parts,
     { type: LinePartType.Text, value: ' ' },
-    { className: ClassNames.OutputSourceLink, label: getSourceLabel(parsed.source, parsed.line), type: LinePartType.Link, value: parsed.source },
+    {
+      className: ClassNames.OutputSourceLink,
+      label: getSourceLabel(parsed.source, parsed.line),
+      lineNumber: parsed.line,
+      type: LinePartType.Link,
+      value: parsed.source,
+    },
   ]
 }

--- a/packages/output-view/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/output-view/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -32,7 +32,7 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
     },
     {
       name: DomEventListenerFunctions.HandleSourceLinkClick,
-      params: ['handleSourceLinkClick', 'event.target.href'],
+      params: ['handleSourceLinkClick', 'event.target.href', 'event.target.dataset.lineNumber', 'event.target.dataset.columnNumber'],
       preventDefault: true,
     },
     {

--- a/packages/output-view/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/output-view/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -32,7 +32,7 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
     },
     {
       name: DomEventListenerFunctions.HandleSourceLinkClick,
-      params: ['handleSourceLinkClick', 'event.target.href', 'event.target.dataset.lineNumber', 'event.target.dataset.columnNumber'],
+      params: ['handleSourceLinkClick', 'event.target.href', 'event.target.dataset.line', 'event.target.dataset.column'],
       preventDefault: true,
     },
     {

--- a/packages/output-view/test/GetLineDom.test.ts
+++ b/packages/output-view/test/GetLineDom.test.ts
@@ -59,7 +59,7 @@ test('getLineDom - renders warning level, repeat count, and shortened source lin
     {
       childCount: 1,
       className: 'OutputSourceLink',
-      'data-line-number': 4496,
+      'data-line': 4496,
       href: 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js',
       onClick: DomEventListenerFunctions.HandleSourceLinkClick,
       rel: 'noopener noreferrer',

--- a/packages/output-view/test/GetLineDom.test.ts
+++ b/packages/output-view/test/GetLineDom.test.ts
@@ -43,6 +43,7 @@ test('getLineDom - renders warning level, repeat count, and shortened source lin
     {
       className: 'OutputSourceLink',
       label: 'rendererWorkerMain.js:4496',
+      lineNumber: 4496,
       type: LinePartType.Link,
       value: 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js',
     },
@@ -58,6 +59,7 @@ test('getLineDom - renders warning level, repeat count, and shortened source lin
     {
       childCount: 1,
       className: 'OutputSourceLink',
+      'data-line-number': 4496,
       href: 'lvce://-/packages/renderer-worker/dist/rendererWorkerMain.js',
       onClick: DomEventListenerFunctions.HandleSourceLinkClick,
       rel: 'noopener noreferrer',

--- a/packages/output-view/test/HandleSourceLinkClick.test.ts
+++ b/packages/output-view/test/HandleSourceLinkClick.test.ts
@@ -9,6 +9,28 @@ test('handleSourceLinkClick - opens the source in the editor', async () => {
   })
   const state = createDefaultState()
 
+  await expect(handleSourceLinkClick(state, 'lvce://-/rendererWorkerMain.js', '3455')).resolves.toBe(state)
+  expect(mockRpc.invocations).toEqual([['Main.openUri', 'lvce://-/rendererWorkerMain.js', true, { selections: new Uint32Array([3454, 0, 3454, 0]) }]])
+})
+
+test('handleSourceLinkClick - opens the source at the given line and column', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUri': () => undefined,
+  })
+  const state = createDefaultState()
+
+  await expect(handleSourceLinkClick(state, 'lvce://-/rendererWorkerMain.js', 3455, 11)).resolves.toBe(state)
+  expect(mockRpc.invocations).toEqual([
+    ['Main.openUri', 'lvce://-/rendererWorkerMain.js', true, { selections: new Uint32Array([3454, 10, 3454, 10]) }],
+  ])
+})
+
+test('handleSourceLinkClick - opens the source without a selection when no line is available', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUri': () => undefined,
+  })
+  const state = createDefaultState()
+
   await expect(handleSourceLinkClick(state, 'lvce://-/rendererWorkerMain.js')).resolves.toBe(state)
   expect(mockRpc.invocations).toEqual([['Main.openUri', 'lvce://-/rendererWorkerMain.js']])
 })

--- a/packages/output-view/test/LoadLines.test.ts
+++ b/packages/output-view/test/LoadLines.test.ts
@@ -39,6 +39,7 @@ test('loadLines - parses and aggregates structured Window logs', async () => {
         {
           className: 'OutputSourceLink',
           label: 'rendererWorkerMain.js:42',
+          lineNumber: 42,
           type: LinePartType.Link,
           value: 'lvce://-/rendererWorkerMain.js',
         },

--- a/packages/output-view/test/ParseLine.test.ts
+++ b/packages/output-view/test/ParseLine.test.ts
@@ -7,7 +7,9 @@ test('parseLine - renders an lvce stack frame as a source link', () => {
     { type: LinePartType.Text, value: '    at load$1 (' },
     {
       className: 'OutputSourceLink',
+      columnNumber: 11,
       label: 'lvce://-/537bcf0/packages/renderer-process/dist/rendererProcessMain.js:8726:11',
+      lineNumber: 8726,
       type: LinePartType.Link,
       value: 'lvce://-/537bcf0/packages/renderer-process/dist/rendererProcessMain.js',
     },

--- a/packages/output-view/test/ParseStructuredLogLine.test.ts
+++ b/packages/output-view/test/ParseStructuredLogLine.test.ts
@@ -21,6 +21,7 @@ test('parseStructuredLogLine - parses a Window NDJSON record', () => {
     {
       className: 'OutputSourceLink',
       label: 'rendererWorkerMain.js:3455',
+      lineNumber: 3455,
       type: LinePartType.Link,
       value: 'lvce://-/d13c194/packages/renderer-worker/dist/rendererWorkerMain.js',
     },

--- a/packages/output-view/test/RenderEventListeners.test.ts
+++ b/packages/output-view/test/RenderEventListeners.test.ts
@@ -10,7 +10,7 @@ test('renderEventListeners - prevents native navigation for source links', () =>
   const result = renderEventListeners()
   expect(result).toContainEqual({
     name: 'handleSourceLinkClick',
-    params: ['handleSourceLinkClick', 'event.target.href'],
+    params: ['handleSourceLinkClick', 'event.target.href', 'event.target.dataset.lineNumber', 'event.target.dataset.columnNumber'],
     preventDefault: true,
   })
 })

--- a/packages/output-view/test/RenderEventListeners.test.ts
+++ b/packages/output-view/test/RenderEventListeners.test.ts
@@ -10,7 +10,7 @@ test('renderEventListeners - prevents native navigation for source links', () =>
   const result = renderEventListeners()
   expect(result).toContainEqual({
     name: 'handleSourceLinkClick',
-    params: ['handleSourceLinkClick', 'event.target.href', 'event.target.dataset.lineNumber', 'event.target.dataset.columnNumber'],
+    params: ['handleSourceLinkClick', 'event.target.href', 'event.target.dataset.line', 'event.target.dataset.column'],
     preventDefault: true,
   })
 })


### PR DESCRIPTION
Preserve source line and column metadata in Output links and pass the corresponding selection when opening the editor. Adds unit and e2e regression coverage for line and column navigation.